### PR TITLE
Corrected code to avoid stream conflict

### DIFF
--- a/Library/Ark/ArkPackage.cs
+++ b/Library/Ark/ArkPackage.cs
@@ -164,15 +164,16 @@ namespace GameArchives.Ark
             IFile arkFile = hdrFile.Parent.GetFile(header.ReadLengthUTF8().Split('/').Last());
             if(version == 10)
             {
-              using(var tmpStream = arkFile.GetStream())
+              var tmpStream = arkFile.GetStream();
+              tmpStream.Seek(-32, SeekOrigin.End);
+
+              if (tmpStream.ReadASCIINullTerminated(32) == "mcnxyxcmvmcxyxcmskdldkjshagsdhfj")
               {
-                tmpStream.Seek(-32, SeekOrigin.End);
-                if(tmpStream.ReadASCIINullTerminated(32) == "mcnxyxcmvmcxyxcmskdldkjshagsdhfj")
-                {
-                  contentFiles[i] = new ProtectedFileStream(arkFile.GetStream());
-                  continue;
-                }
+                contentFiles[i] = new ProtectedFileStream(tmpStream);
+                continue;
               }
+              else
+                tmpStream.Close();
             }
             contentFiles[i] = arkFile.GetStream();
           }


### PR DESCRIPTION
The previous release would throw an exception when calling arkFile.GetStream() while using tmpStream. This new code passes tmpStream and leaves it open when appropriate.

![archiveexplorer_2017-03-26_06-46-19](https://cloud.githubusercontent.com/assets/15707039/24330701/66101dc0-11f2-11e7-990b-15730cae9d66.png)
