### PR TITLE
Fixed parts loading for FSG archives

### DIFF
--- a/Library/FSGIMG/FSGIMGPackage.cs
+++ b/Library/FSGIMG/FSGIMGPackage.cs
@@ -64,7 +64,7 @@ namespace GameArchives.FSGIMG
       {
         int partNum = 1;
         IFile tmp;
-        while (f.Parent.TryGetFile(f.Name.Substring(0, f.Name.Length - 1) + partNum, out tmp))
+        while (f.Parent.TryGetFile($"{f.Name.Substring(0, f.Name.Length - 3)}{partNum:d3}", out tmp))
         {
           var fs = tmp.GetStream();
           parts.Add(fs);

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The library will handle these files in addition to the combined DISC0.img.
 This format is used in some FreeStyleGames games, including:
 * DJ Hero 1,2
 * Guitar Hero Live
+* Sing Party
 
 This format may use compression.
 


### PR DESCRIPTION
Another FSG developed game, Sing Party on Wii U, is split into 23 parts. Current implementation was limited to searching for 10 parts. I've increased that limit to 1000. It appears to load and extract all files without issue.